### PR TITLE
BUG: EventCards display dates 1 day early

### DIFF
--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -66,7 +66,7 @@ export default function EventCard({ event }: { event: any }) {
 
       <p className="text-gray-600 mb-1 text-lg">
         {event.date
-          ? new Date(event.date).toLocaleDateString("en-US", {
+          ? new Date(`${event.date}T00:00:00`).toLocaleDateString("en-US", {
               weekday: "long",
               month: "long",
               day: "numeric",


### PR DESCRIPTION
There was a bug where, I believe, due to time zones, dates were displayed 1 day earlier than intended in Event Cards. Bug smashed.