### PR TITLE
feat/72-board-member-visibility-toggle

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -559,6 +559,33 @@ export default function AdminPage() {
     }
   };
 
+  const handleToggleVisibility = async (id: string, currentStatus: string) => {
+  const newStatus = currentStatus === 'visible' ? 'hidden' : 'visible';
+
+  try {
+    const { error } = await supabase
+      .from('board_members')
+      .update({ status: newStatus })
+      .eq('id', id);
+
+    if (error) {
+      console.error('Error toggling visibility:', error);
+      showError('Error', 'Failed to toggle board member visibility.');
+      return;
+    }
+
+    // Refresh the list of members
+    fetchData();
+    showSuccess(
+      'Success',
+      `Board member is now ${newStatus === 'visible' ? 'visible' : 'hidden'} on the public site.`
+    );
+  } catch (err) {
+    console.error('Error toggling visibility:', err);
+    showError('Error', 'Failed to toggle board member visibility.');
+  }
+};
+
   // Resource management functions
   const handleCreateResource = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -945,6 +972,7 @@ export default function AdminPage() {
                 handleCreateBoardMember={handleCreateBoardMember}
                 handleEditBoardMember={handleEditBoardMember}
                 handleDeleteBoardMember={handleDeleteBoardMember}
+                handleToggleVisibility={handleToggleVisibility}
                 openCreateBoardMember={openCreateBoardMember}
                 closeBoardMemberForm={closeBoardMemberForm}
               />

--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -4,6 +4,7 @@ export default async function AboutSection() {
   const { data: board, error } = await supabase
     .from("board_members")
     .select("*")
+    .eq('status', 'visible')
     .order("order_index", { ascending: true });
 
   if (error) {

--- a/components/admin/tabs/BoardTab.tsx
+++ b/components/admin/tabs/BoardTab.tsx
@@ -15,6 +15,7 @@ interface BoardTabProps {
   handleCreateBoardMember: (e: React.FormEvent) => void;
   handleEditBoardMember: (member: BoardMember) => void;
   handleDeleteBoardMember: (id: string, name: string) => void;
+  handleToggleVisibility: (id: string, currentStatus: string) => void;
   openCreateBoardMember: () => void;
   closeBoardMemberForm: () => void;
 }
@@ -29,6 +30,7 @@ export const BoardTab: React.FC<BoardTabProps> = ({
   handleCreateBoardMember,
   handleEditBoardMember,
   handleDeleteBoardMember,
+  handleToggleVisibility,
   openCreateBoardMember,
   closeBoardMemberForm
 }) => {
@@ -46,11 +48,13 @@ export const BoardTab: React.FC<BoardTabProps> = ({
     );
   }, [boardMembers, query]);
 
-  const sortedMembers = useMemo(() => {
-    if (!sort.key || !sort.direction) return filteredMembers;
-    const arr = [...filteredMembers];
-    const dir = sort.direction === 'asc' ? 1 : -1;
-    arr.sort((a, b) => {
+  const groupedMembers = useMemo(() => {
+    const visible = filteredMembers.filter((m) => m.status === 'visible');
+    const hidden = filteredMembers.filter((m) => m.status !== 'visible');
+
+    const sortFn = (a: BoardMember, b: BoardMember) => {
+      if (!sort.key || !sort.direction) return 0;
+      const dir = sort.direction === 'asc' ? 1 : -1;
       switch (sort.key) {
         case 'name':
           return dir * (a.name || '').localeCompare(b.name || '');
@@ -61,61 +65,127 @@ export const BoardTab: React.FC<BoardTabProps> = ({
         default:
           return 0;
       }
-    });
-    return arr;
+    };
+
+    if (sort.key && sort.direction) {
+      visible.sort(sortFn);
+      hidden.sort(sortFn);
+    }
+
+    return { visible, hidden };
   }, [filteredMembers, sort]);
 
   return (
-  <div>
-    <div className="flex justify-between items-center mb-6 gap-3">
-      <h2 className="text-xl font-semibold text-gray-800">Board Members</h2>
-      <div className="flex-1 hidden md:block" />
-      <SearchInput value={query} onChange={setQuery} placeholder="Search members..." />
-      <button className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700" onClick={openCreateBoardMember}>
-        Add New Member
-      </button>
-    </div>
-    
-    {(editingBoardMember || showCreateBoardMember) && (
-      <BoardMemberForm
-        isEditing={!!editingBoardMember}
-        formData={newBoardMember}
-        onFormChange={handleBoardFormChange}
-        onSubmit={editingBoardMember ? handleUpdateBoardMember : handleCreateBoardMember}
-        onCancel={closeBoardMemberForm}
-      />
-    )}
-
-    {boardMembers.length === 0 ? (
-      <EmptyState message="No board members found." />
-    ) : (
-      <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
-            <tr>
-              <SortableHeader label="Name" columnKey="name" sort={sort} onChange={setSort} className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" />
-              <SortableHeader label="Role" columnKey="role" sort={sort} onChange={setSort} className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" />
-              <SortableHeader label="Email" columnKey="email" sort={sort} onChange={setSort} className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" />
-              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
-            </tr>
-          </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
-            {sortedMembers.map(member => (
-              <tr key={member.id}>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{member.name}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{member.role}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{member.email}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
-                  <button onClick={() => handleEditBoardMember(member)} className="text-blue-600 hover:text-blue-900">Edit</button>
-                  <button onClick={() => handleDeleteBoardMember(member.id, member.name)} className="text-red-600 hover:text-red-900">Delete</button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+    <div>
+      <div className="flex justify-between items-center mb-6 gap-3">
+        <h2 className="text-xl font-semibold text-gray-800">Board Members</h2>
+        <div className="flex-1 hidden md:block" />
+        <SearchInput value={query} onChange={setQuery} placeholder="Search members..." />
+        <button className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700" onClick={openCreateBoardMember}>
+          Add New Member
+        </button>
       </div>
-    )}
-  </div>
-);
+
+      {(editingBoardMember || showCreateBoardMember) && (
+        <BoardMemberForm
+          isEditing={!!editingBoardMember}
+          formData={newBoardMember}
+          onFormChange={handleBoardFormChange}
+          onSubmit={editingBoardMember ? handleUpdateBoardMember : handleCreateBoardMember}
+          onCancel={closeBoardMemberForm}
+        />
+      )}
+
+      {boardMembers.length === 0 ? (
+        <EmptyState message="No board members found." />
+      ) : (
+        <div className="space-y-8">
+          {/* Visible Members Group */}
+          {groupedMembers.visible.length > 0 && (
+            <div className="border rounded-lg overflow-hidden">
+              <div className="px-4 py-3 bg-gray-50 flex items-center justify-between">
+                <div>
+                  <div className="text-sm text-gray-500">Group</div>
+                  <div className="text-base font-medium text-gray-900">Visible Members</div>
+                </div>
+                <div className="text-sm text-gray-700">
+                  {groupedMembers.visible.length} member{groupedMembers.visible.length === 1 ? '' : 's'}
+                </div>
+              </div>
+
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <SortableHeader label="Name" columnKey="name" sort={sort} onChange={setSort} className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" />
+                      <SortableHeader label="Role" columnKey="role" sort={sort} onChange={setSort} className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" />
+                      <SortableHeader label="Email" columnKey="email" sort={sort} onChange={setSort} className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" />
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {groupedMembers.visible.map(member => (
+                      <tr key={member.id}>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{member.name}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{member.role}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{member.email}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                          <button onClick={() => handleEditBoardMember(member)} className="text-blue-600 hover:text-blue-900">Edit</button>
+                          <button onClick={() => handleToggleVisibility(member.id, member.status)} className="text-yellow-600 hover:text-yellow-800">Hide</button>
+                          <button onClick={() => handleDeleteBoardMember(member.id, member.name)} className="text-red-600 hover:text-red-900">Delete</button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Hidden Members Group */}
+          {groupedMembers.hidden.length > 0 && (
+            <div className="border rounded-lg overflow-hidden opacity-80">
+              <div className="px-4 py-3 bg-gray-100 flex items-center justify-between">
+                <div>
+                  <div className="text-sm text-gray-500">Group</div>
+                  <div className="text-base font-medium text-gray-900">Hidden Members</div>
+                </div>
+                <div className="text-sm text-gray-700">
+                  {groupedMembers.hidden.length} hidden member{groupedMembers.hidden.length === 1 ? '' : 's'}
+                </div>
+              </div>
+
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <SortableHeader label="Name" columnKey="name" sort={sort} onChange={setSort} className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" />
+                      <SortableHeader label="Role" columnKey="role" sort={sort} onChange={setSort} className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" />
+                      <SortableHeader label="Email" columnKey="email" sort={sort} onChange={setSort} className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" />
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {groupedMembers.hidden.map(member => (
+                      <tr key={member.id} className="bg-gray-50">
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{member.name}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{member.role}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{member.email}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                          <button onClick={() => handleEditBoardMember(member)} className="text-blue-600 hover:text-blue-900">Edit</button>
+                          <button onClick={() => handleToggleVisibility(member.id, member.status)} className="text-green-600 hover:text-green-800">Show</button>
+                          <button onClick={() => handleDeleteBoardMember(member.id, member.name)} className="text-red-600 hover:text-red-900">Delete</button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
 };
 

--- a/components/admin/types.ts
+++ b/components/admin/types.ts
@@ -35,6 +35,7 @@ export type BoardMember = {
   name: string;
   role: string;
   email: string;
+  status: string;
 };
 
 export type Resource = {


### PR DESCRIPTION
Added a button in the admin panel to hide board members. Hidden board members do not show up on the home page. Also, the admin page now sorts board members into groups like the RSVP tab, only with 2 set groups: visible and hidden.