### PR TITLE
fe/79-admin-open-close-toggle

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -15,6 +15,7 @@ import { BoardTab } from '@/components/admin/tabs/BoardTab';
 import { ResourcesTab } from '@/components/admin/tabs/ResourcesTab';
 import { SponsorsTab } from '@/components/admin/tabs/SponsorsTab';
 import type { Event, RSVP, Photo, BoardMember, Resource, Sponsor } from '@/components/admin/types';
+import AdminCenterToggle from "@/components/admin/AdminCenterToggle";
 
 
 export default function AdminPage() {
@@ -867,6 +868,11 @@ export default function AdminPage() {
             </div>
           </div>
         </div>
+
+        {/* Center Status Toggle */}
+  <div className="my-4">
+    <AdminCenterToggle />
+  </div>
 
         <StatsCards 
           events={events.length}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import Footer from "@/components/Footer";
 import { ToastProvider } from "@/contexts/ToastContext";
 import { ConfirmationProvider } from "@/contexts/ConfirmationContext";
 import type { Metadata } from "next";
+import CenterClosedPopup from "@/components/CenterClosedPopup";
 
 
 export const metadata: Metadata = {
@@ -22,6 +23,7 @@ export default function RootLayout({
         <ToastProvider>
           <ConfirmationProvider>
             <Navbar />
+            <CenterClosedPopup />
             <main className="max-w-6xl mx-auto px-4 py-8">{children}</main>
             <Footer />
           </ConfirmationProvider>

--- a/components/CenterClosedPopup.tsx
+++ b/components/CenterClosedPopup.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabaseClient";
+
+interface CenterStatus {
+  id: number;
+  is_closed: boolean;
+  message: string | null;
+}
+
+export default function CenterClosedPopup() {
+  const [status, setStatus] = useState<CenterStatus>({
+    id: 1,
+    is_closed: false,
+    message: null,
+  });
+
+  useEffect(() => {
+    // Fetch current status
+    const fetchStatus = async () => {
+      const { data, error } = await supabase
+        .from("center_status")
+        .select("id, is_closed, message")
+        .eq("id", 1)
+        .single();
+
+      if (!error && data) {
+        setStatus({
+          id: data.id,
+          is_closed: data.is_closed,
+          message: data.message,
+        });
+      }
+    };
+
+    fetchStatus();
+
+    // Realtime subscription
+    const channel = supabase
+      .channel("public:center_status")
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "center_status",
+          filter: "id=eq.1",
+        },
+        (payload) => {
+          const newData = payload.new as CenterStatus;
+          setStatus({
+            id: newData.id,
+            is_closed: newData.is_closed,
+            message: newData.message,
+          });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, []);
+
+  if (!status.is_closed) return null;
+
+  const displayMessage =
+    status.message && status.message.trim() !== ""
+      ? status.message
+      : "Attention: The Center is Closed Today.";
+
+  return (
+    <div className="fixed top-20 left-1/2 transform -translate-x-1/2 bg-red-600 text-white p-4 rounded shadow-lg z-50 max-w-xl text-center">
+      {displayMessage}
+    </div>
+  );
+}

--- a/components/admin/AdminCenterToggle.tsx
+++ b/components/admin/AdminCenterToggle.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { supabase } from "@/lib/supabaseClient";
+import { useToast } from "@/contexts/ToastContext";
+
+export default function AdminCenterToggle() {
+  const [isClosed, setIsClosed] = useState<boolean | null>(null);
+  const [message, setMessage] = useState<string>("");
+  const [showMessageInput, setShowMessageInput] = useState(false);
+  const { showSuccess, showError } = useToast();
+
+  // Fetch current status + message
+  useEffect(() => {
+    const fetchStatus = async () => {
+      const { data, error } = await supabase
+        .from("center_status")
+        .select("is_closed, message")
+        .eq("id", 1)
+        .single();
+
+      if (error) {
+        showError("Error fetching center status", error.message);
+        return;
+      }
+
+      setIsClosed(data.is_closed);
+      setMessage(data.message || "");
+    };
+
+    fetchStatus();
+  }, [showError]);
+
+  // Handles main button click
+  const handleToggleClick = () => {
+    if (isClosed === null) return;
+
+    if (!isClosed) {
+      // Currently open → intent to close → show message input
+      setShowMessageInput(true);
+    } else {
+      // Currently closed → mark as open immediately
+      toggleStatus(false, null);
+    }
+  };
+
+  // Updates the database
+  const toggleStatus = async (closing: boolean, msg: string | null) => {
+    const { error } = await supabase
+      .from("center_status")
+      .update({
+        is_closed: closing,
+        updated_at: new Date(),
+        message: closing ? msg : null, // clear message when opening
+      })
+      .eq("id", 1);
+
+    if (error) {
+      showError("Error updating status", error.message);
+      return;
+    }
+
+    setIsClosed(closing);
+    setMessage(""); // clear local message
+    setShowMessageInput(false);
+
+    showSuccess(
+      "Center status updated",
+      `Center is now ${closing ? "CLOSED" : "OPEN"}`
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center space-x-2">
+        <button
+          onClick={handleToggleClick}
+          className={`px-4 py-2 font-bold rounded ${
+            isClosed ? "bg-green-600 text-white" : "bg-red-600 text-white"
+          }`}
+        >
+          {isClosed === null
+            ? "Loading..."
+            : isClosed
+            ? "Mark Center as Open"
+            : "Mark Center as Closed"}
+        </button>
+      </div>
+
+      {showMessageInput && (
+        <div className="flex flex-col space-y-2 mt-2">
+          <label htmlFor="center-message" className="font-medium text-gray-700">
+            Optional message for popup:
+          </label>
+          <input
+            type="text"
+            id="center-message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            className="border px-2 py-1 rounded w-full"
+            placeholder="Attention: The Center is Closed Today."
+          />
+          <div className="flex space-x-2">
+            <button
+              onClick={() => toggleStatus(true, message)}
+              className="bg-green-600 text-white px-4 py-2 rounded"
+            >
+              Confirm
+            </button>
+            <button
+              onClick={() => {
+                setShowMessageInput(false);
+                setMessage("");
+              }}
+              className="bg-gray-300 px-4 py-2 rounded"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
I added a toggle button to the Admin page, which marks the center as open or closed, with an optional text message. There is also now a pop-up in the overall layout.tsx, which only appears when the center is closed.

I also made some pretty significant backend changes: a new table with 1 row for the open/closed status of the center.
I also tried implementing an Edge Function in the Supabase to automatically reset the center to open at midnight.